### PR TITLE
Added support for custom 'type'

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The below are available plugin configuration parameters:
 export interface BrokerEmitterConfig {
     vendor: "aws",
     broker: "sns",
+    type?: string,
     sns?: SnsBrokerEmitter,
     loggingLevel?: "silly" | "debug" | "verbose" | "http" | "info" | "warn" | "error"
 }
@@ -40,9 +41,12 @@ config:
       loggingLevel: silly
       broker: sns
       vendor: aws
+      type: stress
       sns:
         arn: arn:aws:sns:us-east-1:1234567890:artillery-test
 ```
+
+> Note: Adding a config `type` key will change the event emitted to be `<artillery-event>.<type>`. For example, when doing a stress type, the done event will now emit `done.stress` to external brokers.
 
 ### AWS Setup
 For AWS Setup, the below environment variables need to be configured:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artillery-plugin-emitter",
-  "version": "1.0.10",
+  "version": "1.0.12",
   "description": "send artillery events to a variety of event brokers",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,16 +74,18 @@ export class Plugin {
 
     async handleDoneEvent(data: any) {
         this.logger.silly("sending 'done' event data");
+        let type = this.config.type ? `done.${this.config.type}` : 'done';
         this.doneEventPromise = this.emit(data, {
-            type: 'done',
+            type,
             source: 'artillery'
         });
     }
 
     async handleStatsEvent(data: any) {
         this.logger.silly("sending 'stats' event data");
+        let type = this.config.type ? `stats.${this.config.type}` : 'stats';
         await this.emit(data, {
-            type: 'stats',
+            type,
             source: 'artillery'
         });
         this.logger.silly("finished sending 'stats' event data");
@@ -91,8 +93,9 @@ export class Plugin {
 
     async handlePhaseCompletedEvent(data: any) {
         this.logger.silly("sending 'phaseCompleted' event data");
+        let type = this.config.type ? `phaseCompleted.${this.config.type}` : 'phaseCompleted';
         await this.emit(data, {
-            type: 'phaseCompleted',
+            type,
             source: 'artillery'
         });
         this.logger.silly("finished sending 'phaseCompleted' event data");
@@ -100,8 +103,9 @@ export class Plugin {
 
     async handlePhaseStartedEvent(data: any) {
         this.logger.silly("sending 'phaseStarted' event data");
+        let type = this.config.type ? `phaseStarted.${this.config.type}` : 'phaseStarted';
         await this.emit(data, {
-            type: 'phaseStarted',
+            type,
             source: 'artillery'
         });
         this.logger.silly("finished sending 'phaseStarted' event data");

--- a/src/interfaces/broker-emitter.ts
+++ b/src/interfaces/broker-emitter.ts
@@ -13,6 +13,7 @@ export interface ArtilleryPlugins {
 export interface BrokerEmitterConfig {
     vendor: "aws",
     broker: "sns",
+    type?: string
     sns?: SnsBrokerEmitter,
     loggingLevel?: "silly" | "debug" | "verbose" | "http" | "info" | "warn" | "error"
 }


### PR DESCRIPTION
This is to satisfy the scenario when a category of artillery test is performed (ie stress or baseline)